### PR TITLE
Use snake_case in openxlsx2 arguments

### DIFF
--- a/R/wb_apply_cell_styles.R
+++ b/R/wb_apply_cell_styles.R
@@ -46,8 +46,8 @@ wb_apply_cell_styles <- function(wb, sheet, df_style) {
       dims = crow$dims,
       horizontal = crow$text.align,
       vertical = crow$vertical.align,
-      textRotation = crow$text.direction,
-      wrapText = "1"
+      text_rotation = crow$text.direction,
+      wrap_text = "1"
     )
 
     if (crow$background.color != "transparent") {


### PR DESCRIPTION
Just a minor change found in preparation of https://github.com/JanMarvin/openxlsx2/pull/1330. This is not pressing, `openxlsx2` will not change camelCase before the next major release, but this prepares `flexlsx` for the change.

```R
options("openxlsx2.soon_deprecated" = TRUE)
library(flextable)
library(flexlsx)
devtools::load_all(".")
testthat::test_dir("tests/testthat")
```